### PR TITLE
Named Crystal colors no longer drop as Color_Crystals due to NPC combat level

### DIFF
--- a/MMOCoreORB/bin/scripts/loot/groups/named_crystals.lua
+++ b/MMOCoreORB/bin/scripts/loot/groups/named_crystals.lua
@@ -16,7 +16,7 @@ named_crystals = {
 		{itemTemplate = "force_crystal_mundis_response", weight = 588235},
 		{itemTemplate = "force_crystal_prowess_of_plo_koon", weight = 588235},
 		{itemTemplate = "force_crystal_qui_gons_devotion", weight = 588236},
-		{itemTemplate = "force_crystal_quintessebce_of_the_force", weight = 588236},
+		{itemTemplate = "force_crystal_quintessence_of_the_force", weight = 588236},
 		{itemTemplate = "force_crystal_strength_of_luminaria", weight = 588236},
 		{itemTemplate = "force_crystal_ulics_redemption", weight = 588236},
 		{itemTemplate = "force_crystal_windus_guile", weight = 588236},

--- a/MMOCoreORB/bin/scripts/loot/items/force_color_crystal.lua
+++ b/MMOCoreORB/bin/scripts/loot/items/force_color_crystal.lua
@@ -6,7 +6,7 @@ force_color_crystal = {
 	customObjectName = "",
 	directObjectTemplate = "object/tangible/component/weapon/lightsaber/lightsaber_module_force_crystal.iff",
 	craftingValues = {
-		{"color",0,11,0},
+		{"color",0,0,0},
 	},
 	customizationStringNames = {},
 	customizationValues = {}

--- a/MMOCoreORB/src/server/zone/objects/tangible/component/lightsaber/LightsaberCrystalComponentImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/tangible/component/lightsaber/LightsaberCrystalComponentImplementation.cpp
@@ -445,20 +445,26 @@ void LightsaberCrystalComponentImplementation::updateCrystal(int value){
 }
 
 void LightsaberCrystalComponentImplementation::updateCraftingValues(CraftingValues* values, bool firstUpdate) {
+	String crystalTemplate = getObjectTemplate()->getCustomName();
+
 	int colorMax = values->getMaxValue("color");
 	int color = values->getCurrentValue("color");
 
 	if (colorMax != 31) {
-		int finalColor = Math::min(color, 30);
-		setColor(finalColor);
-		updateCrystal(finalColor);
+		if (colorMax == 0 && crystalTemplate.isEmpty()) {
+			int finalColor = System::random(11);
+			setColor(finalColor);
+			updateCrystal(finalColor);
+		} else if (colorMax >= 12) {
+			setColor(color);
+			updateCrystal(color);
+		}
 	} else {
 		setColor(31);
 		updateCrystal(31);
 	}
 
 	generateCrystalStats();
-
 	ComponentImplementation::updateCraftingValues(values, firstUpdate);
 }
 


### PR DESCRIPTION
Testing:
/object createloot color_crystals
/object createloot color_crystals 450
/object createloot named_crystals
/object createloot named_crystals 450

Empty inventory:
/tar self
/wipeitems    (Deletes all items in inventory except equipped items.)
