### PR TITLE
Players will no longer be set covert when cloning if they are neutral, making turrets attackable.

### DIFF
--- a/MMOCoreORB/src/server/zone/managers/player/PlayerManagerImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/managers/player/PlayerManagerImplementation.cpp
@@ -1531,7 +1531,8 @@ void PlayerManagerImplementation::sendPlayerToCloner(CreatureObject* player, uin
 	}
 	// TEF FIX
 	// Clone as Covert
-	if (player->getFactionStatus() != FactionStatus::COVERT && cbot->getFacilityType() != CloningBuildingObjectTemplate::FACTION_IMPERIAL && cbot->getFacilityType() != CloningBuildingObjectTemplate::FACTION_REBEL && !player->hasSkill("force_title_jedi_rank_03"))
+
+	if (player->getFaction() != 0 && player->getFactionStatus() != FactionStatus::COVERT && cbot->getFacilityType() != CloningBuildingObjectTemplate::FACTION_IMPERIAL && cbot->getFacilityType() != CloningBuildingObjectTemplate::FACTION_REBEL && !player->hasSkill("force_title_jedi_rank_03"))
 		player->setFactionStatus(FactionStatus::COVERT);
 	// TEF FIX Should stay TEF until Clone
 	if (ghost->hasPvpTef() || ghost->hasRealGcwTef() || ghost->hasGroupTef()) {


### PR DESCRIPTION
Also put in a statement to set neutral players back On Leave if they are already stuck in the covert state, which will fix the already bugged players. 