### PR TITLE
Improve GCW mission faction point rewards

### DIFF
--- a/MMOCoreORB/bin/scripts/managers/faction_manager.lua
+++ b/MMOCoreORB/bin/scripts/managers/faction_manager.lua
@@ -82,6 +82,16 @@ factionList = {
 }
 
 maxFactionRank = 15
+-- Where to determine the amount of faction points to award for missions. Valid
+-- options are "min_level" (SWG default), "difficulty_level" (the actual level
+-- rolled for the mission), or "difficulty_display" (what the player sees in the
+-- mission details).
+-- missionRewardType = "min_level"
+-- The maximum amount of faction points (before scaling) to award for missions.
+-- missionRewardCap = 32
+-- When set to true, each rank will award slightly more faction points based on
+-- the delegate ratios.
+-- missionRewardRankScaling = false
 -- When true, displays the player's PvP officer faction ranks as a skill tree.
 -- Requires .tre patch with "faction_rank" skill trees ()
 -- factionSkillTree = false
@@ -140,6 +150,9 @@ maxFactionRank = 15
 
 -- SWGIntended: GCW Revamp
 -- maxFactionRank = 21
+missionRewardType = "difficulty_display"
+missionRewardCap = -1
+missionRewardRankScaling = true
 factionSkillTree = true
 factionSkillTreeNames = {
 	imperial = {

--- a/MMOCoreORB/bin/scripts/managers/mission/mission_manager.lua
+++ b/MMOCoreORB/bin/scripts/managers/mission/mission_manager.lua
@@ -77,18 +77,23 @@ playerBountyKillBuffer = 30 * 60 * 1000 -- Buffer before player bounty can be pu
 playerBountyDebuffLength = 3 * 24 * 60 * 60 * 1000 -- Time before their bounty resets from the minimum amount
 
 -- Destroy Mission Configuration
--- Distance calculated as: 
---    <BaseDistance> + <DifficultyDistanceFactor> * <difficultyLevel> + 
+-- Distance calculated as:
+--    <BaseDistance> + <DifficultyDistanceFactor> * <difficultyLevel> +
 --    rand(<RandomDistance>) + rand(<DifficutlyRandomDistance * <difficultyLevel>)
 destroyMissionBaseDistance = 1000
 destroyMissionDifficultyDistanceFactor = 0
 destroyMissionRandomDistance = 1000
 destroyMissionDifficultyRandomDistance = 0
 
--- Mission payout calculated as: 
---    <BaseReward> + <DifficultyRewardFactor> * <difficultyLevel> + 
+-- Mission payout calculated as:
+--    <BaseReward> + <DifficultyRewardFactor> * <difficultyLevel> +
 --    rand(<RandomReward>) + rand(<DifficutlyRandomReward * <difficultyLevel>)
 destroyMissionBaseReward = 0
 destroyMissionDifficultyRewardFactor = 375
 destroyMissionRandomReward = 0
 destroyMissionDifficultyRandomReward = 15
+
+-- enableGroupFactionPointRewards = false
+
+-- SWGIntended: GCW revamp
+enableGroupFactionPointRewards = true

--- a/MMOCoreORB/src/server/zone/managers/faction/FactionManager.h
+++ b/MMOCoreORB/src/server/zone/managers/faction/FactionManager.h
@@ -10,6 +10,7 @@
 
 #include "FactionMap.h"
 #include "server/zone/objects/creature/CreatureObject.h"
+#include "server/zone/objects/mission/MissionObject.h"
 #include "server/zone/objects/player/PlayerObject.h"
 #include "system/lang.h"
 #include "templates/faction/FactionRanks.h"
@@ -58,8 +59,8 @@ public:
 
 	String getRankName(int idx);
 	int getRankCost(int rank);
-	int getRankDelegateRatioFrom(int rank);
-	int getRankDelegateRatioTo(int rank);
+	int getRankDelegateRatioFrom(int rank) const;
+	int getRankDelegateRatioTo(int rank) const;
 	String getRankSkillName(const String& faction, int rank) const;
 	int getFactionPointsCap(int rank);
 
@@ -75,6 +76,8 @@ public:
 	bool isEnemy(const String& faction1, const String& faction2);
 	bool isAlly(const String& faction1, const String& faction2);
 
+	int getMissionFactionPointReward(int minLevel, MissionObject* mission, CreatureObject* player) const;
+
 	bool isFactionSkillTreeEnabled() const {
 		return factionSkillTree;
 	}
@@ -88,6 +91,9 @@ protected:
 
 private:
 	int maxFactionRank = 15;
+	int missionRewardCap;
+	String missionRewardType;
+	bool missionRewardRankScaling;
 	bool factionSkillTree = false;
 	VectorMap<String, Vector<String>*> factionSkillTreeNames;
 

--- a/MMOCoreORB/src/server/zone/managers/mission/MissionManager.idl
+++ b/MMOCoreORB/src/server/zone/managers/mission/MissionManager.idl
@@ -69,6 +69,8 @@ class MissionManager extends Observer implements Logger {
 	unsigned long destroyMissionRandomReward;
 	unsigned long destroyMissionDifficultyRandomReward;
 
+	protected boolean enableGroupFactionPointRewards;
+
 	public MissionManager(ZoneServer srv, ZoneProcessServer impl) {
 		server = srv;
 		processor = impl;
@@ -196,4 +198,9 @@ class MissionManager extends Observer implements Logger {
 
 	@arg1preLocked
 	public native boolean sendPlayerBountyDebug(CreatureObject player, CreatureObject target);
+
+	@read
+	public boolean isGroupFactionPointRewardsEnabled() {
+		return enableGroupFactionPointRewards;
+	}
 }

--- a/MMOCoreORB/src/server/zone/objects/mission/MissionObjective.idl
+++ b/MMOCoreORB/src/server/zone/objects/mission/MissionObjective.idl
@@ -6,6 +6,7 @@ package server.zone.objects.mission;
 
 import engine.util.Observable;
 import system.util.SortedVector;
+import system.util.Vector;
 import server.zone.objects.creature.CreatureObject;
 
 include engine.log.Logger;
@@ -136,4 +137,8 @@ class MissionObjective extends ManagedObject implements Logger {
 	public abstract native Vector3 getEndPosition();
 
 	public native void clearFailTask();
+
+	@reference
+	@local
+	private native Vector<CreatureObject> getAwardPlayers(boolean playMissionComplete);
 }

--- a/MMOCoreORB/src/server/zone/objects/mission/MissionObjectiveImplementation.cpp
+++ b/MMOCoreORB/src/server/zone/objects/mission/MissionObjectiveImplementation.cpp
@@ -137,7 +137,7 @@ void MissionObjectiveImplementation::awardFactionPoints() {
 
 		for (int i = 0; i < players->size(); i++) {
 			ManagedReference<CreatureObject*> player = players->get(i);
-			if (player->getFaction() == mission->getFaction()) {
+			if (player->getFaction() != mission->getFaction()) {
 				// Prevent grouped players of opposite factions from losing faction
 				// standing if they are nearby
 				continue;


### PR DESCRIPTION
- increased faction points from missions
- faction points scale slightly with rank based on delegate ratio
- faction points are split amongst group members

This PR is intended to compliment removing FP gain from NPCs.

Taking a difficulty 60 mission (about 10,000 credits) solo at rank 0 results gives 120 faction upon destroying the objective.

Previously, the destruction of the objective would grant 50 faction. Killing the 5-8 NPCs would grant an additional 150-200 faction.

With rank scaling, at the rank of Warrant Officer II, a difficulty 60 mission grants 180 faction (1.5 modifier), and at the rank of Colonel it grants 262 faction (1.9 modifier and 15% bonus from Loyalty).

Another aspect of this change is removing the mission level cap for faction. Grouping up with another player can easily grant access to a difficulty 90 mission, which grants 393 faction.

The result is increasing rewards as the player ranks up, groups up, and levels up as opposed to a flat FP reward payout.